### PR TITLE
fix: use the correct version of the extension in standalone/run.sh

### DIFF
--- a/standalone/run.sh
+++ b/standalone/run.sh
@@ -7,4 +7,4 @@ then
 fi
 
 protoc --descriptor_set_out wiremock-data/grpc/services.dsc ExampleServices.proto
-java -cp wiremock-standalone-3.3.1.jar:wiremock-grpc-extension-standalone-0.3.0.jar wiremock.Run --port 8000 --root-dir wiremock-data
+java -cp wiremock-standalone-3.3.1.jar:wiremock-grpc-extension-standalone-0.4.0.jar wiremock.Run --port 8000 --root-dir wiremock-data


### PR DESCRIPTION
This PR makes sure the version of the grpc-extension is also updated in `standalone/run.sh`

## References

- N/A

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [x] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
